### PR TITLE
Add optional Apprise notification backend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM denoland/deno:alpine
 
-RUN apk add --no-cache jq curl
+RUN apk add --no-cache jq curl apprise
 
 WORKDIR /app
 
@@ -11,6 +11,6 @@ COPY * ./
 
 RUN chmod +x *.sh
 
-RUN deno cache main.ts
+RUN deno cache validateEnv.ts main.ts
 
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -1,13 +1,31 @@
 # Bahnhof Price Check
 
-Check the current price of Bahnhof's internet service and send an email if the price has changed.
+Check the current price of Bahnhof's internet service and send a notification if the price has changed.
 
 ## Usage
 
 ### Docker compose
 
+Use Apprise by setting `APPRISE_URL` to [any URL supported by Apprise](https://appriseit.com/services/), such as `discord://...` or `ntfy://...`.
+
 ```
-version: '3'
+services:
+  bahnhof-price-checker:
+    image: ghcr.io/patrikelfstrom/bahnhof-price-checker:latest
+    container_name: bahnhof-price-checker
+    environment:
+      - ADDRESS=Rådhusgatan 5, 590 37 Kisa, Sweden
+      - CURRENT_SPEED=500/100
+      - CURRENT_PRICE=459
+      - APPRISE_URL=discord://{webhook_id}/{webhook_token}
+      - APPRISE_TITLE=Bahnhof Price Change
+      - CRON_SCHEDULE=0 0 * * *
+    restart: always
+```
+
+You can also use email notifications by setting all `MAIL_*` variables:
+
+```
 services:
   bahnhof-price-checker:
     image: ghcr.io/patrikelfstrom/bahnhof-price-checker:latest
@@ -27,10 +45,15 @@ services:
     restart: always
 ```
 
+At least one notification channel is required: set `APPRISE_URL` or all `MAIL_*` variables.
+If both Apprise and email are configured, both notifications will be sent.
+
+`APPRISE_TITLE` is optional and defaults to `MAIL_SUBJECT` or `Bahnhof Price Change`.
+
 ### Call shell scripts directly
 
 Clone the repo and just call comparePrice.sh with your current speed, price and address.
-No mail will be sent using this method.
+No notification will be sent using this method.
 
 Requires jq, cURL and Sed.
 

--- a/config.ts
+++ b/config.ts
@@ -1,0 +1,73 @@
+import { load } from "./deps.ts";
+
+const env = await load();
+
+export const mailEnvironmentVariables = [
+  "MAIL_SUBJECT",
+  "MAIL_FROM",
+  "MAIL_TO",
+  "MAIL_HOST",
+  "MAIL_PORT",
+  "MAIL_USERNAME",
+  "MAIL_PASSWORD",
+];
+
+export function getEnv(variable: string) {
+  return env[variable] ?? Deno.env.get(variable);
+}
+
+export function getRequiredEnv(variable: string) {
+  const value = getEnv(variable);
+
+  if (value === undefined) {
+    console.error(`❌ Required environment variable '${variable}' is not set.`);
+    Deno.exit(1);
+  }
+
+  return value;
+}
+
+export function isMailConfigured() {
+  return mailEnvironmentVariables.every((variable) => Boolean(getEnv(variable)));
+}
+
+export function isAppriseConfigured() {
+  return Boolean(getEnv("APPRISE_URL"));
+}
+
+export function validateEnvironment(options: { includeCron?: boolean } = {}) {
+  const requiredVariables = [
+    "ADDRESS",
+    "CURRENT_SPEED",
+    "CURRENT_PRICE",
+  ];
+
+  if (options.includeCron) {
+    requiredVariables.push("CRON_SCHEDULE");
+  }
+
+  for (const variable of requiredVariables) {
+    getRequiredEnv(variable);
+  }
+
+  const isMailPartiallyConfigured = mailEnvironmentVariables.some((variable) =>
+    getEnv(variable) !== undefined
+  );
+
+  if (isMailPartiallyConfigured && !isMailConfigured()) {
+    for (const variable of mailEnvironmentVariables) {
+      if (getEnv(variable) === undefined) {
+        console.error(`❌ Required environment variable '${variable}' is not set.`);
+      }
+    }
+
+    Deno.exit(1);
+  }
+
+  if (!isMailConfigured() && !isAppriseConfigured()) {
+    console.error(
+      "❌ At least one notification channel must be configured. Set APPRISE_URL or all MAIL_* variables.",
+    );
+    Deno.exit(1);
+  }
+}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,9 @@
 #!/bin/sh
 
-if [ -z "$CRON_SCHEDULE" ]; then
-    echo "❌ CRON_SCHEDULE is not set"
-fi
+set -e
+
+echo "🔍 Validating Environment"
+deno run --allow-env --allow-read /app/validateEnv.ts
 
 echo "🛠️ Installing Cron Job"
 

--- a/main.ts
+++ b/main.ts
@@ -1,33 +1,20 @@
-import { dirname, fromFileUrl, join, load } from "./deps.ts";
+import { dirname, fromFileUrl, join } from "./deps.ts";
+import {
+  getRequiredEnv,
+  isAppriseConfigured,
+  isMailConfigured,
+  validateEnvironment,
+} from "./config.ts";
+import { sendApprise } from "./sendApprise.ts";
 import { sendMail } from "./sendMail.ts";
 
 console.log("💸 Running Bahnhof Price Checker...");
 
-const env = await load();
+validateEnvironment();
 
-const environmentVariables = [
-  "ADDRESS",
-  "CURRENT_SPEED",
-  "CURRENT_PRICE",
-  "MAIL_SUBJECT",
-  "MAIL_FROM",
-  "MAIL_TO",
-  "MAIL_HOST",
-  "MAIL_PORT",
-  "MAIL_USERNAME",
-  "MAIL_PASSWORD",
-];
-
-for (const variable of environmentVariables) {
-  if (Deno.env.has(variable) === false && env[variable] === undefined) {
-    console.error(`❌ Required environment variable '${variable}' is not set.`);
-    Deno.exit(1);
-  }
-}
-
-const address = env["ADDRESS"] ?? Deno.env.get("ADDRESS");
-const currentSpeed = env["CURRENT_SPEED"] ?? Deno.env.get("CURRENT_SPEED");
-const currentPrice = env["CURRENT_PRICE"] ?? Deno.env.get("CURRENT_PRICE");
+const address = getRequiredEnv("ADDRESS");
+const currentSpeed = getRequiredEnv("CURRENT_SPEED");
+const currentPrice = getRequiredEnv("CURRENT_PRICE");
 const currentDirectory = dirname(fromFileUrl(import.meta.url));
 
 const command = new Deno.Command(join(currentDirectory, "./comparePrices.sh"), {
@@ -37,28 +24,54 @@ const command = new Deno.Command(join(currentDirectory, "./comparePrices.sh"), {
 const { code, stdout, stderr } = command.outputSync();
 const response = new TextDecoder().decode(stdout);
 
+function writeOutputWithTrailingNewline(output: Uint8Array) {
+  if (output.length === 0) {
+    return;
+  }
+
+  Deno.stdout.writeSync(output);
+
+  if (output[output.length - 1] !== 10) {
+    Deno.stdout.writeSync(new TextEncoder().encode("\n"));
+  }
+}
+
+function stripAnsiEscapeCodes(text: string) {
+  return text.replace(/\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g, "").trim();
+}
+
 if (stderr.length > 0) {
   Deno.stderr.writeSync(stderr);
 }
 
 if (code === 3) {
-  if (stdout.length > 0) {
-    Deno.stdout.writeSync(stdout);
+  writeOutputWithTrailingNewline(stdout);
+
+  const cleanResponse = stripAnsiEscapeCodes(response);
+
+  const notifications: Promise<void>[] = [];
+
+  if (isMailConfigured()) {
+    notifications.push(sendMail(cleanResponse));
   }
 
-  const cleanResponse = response.replace(/(\[0;31m|\[0;32m|\[0m)/g, "");
+  if (isAppriseConfigured()) {
+    notifications.push(sendApprise(cleanResponse));
+  }
 
-  sendMail(cleanResponse, () => {
-    Deno.exit(1);
-  });
+  const notificationResults = await Promise.allSettled(notifications);
+
+  for (const result of notificationResults) {
+    if (result.status === "rejected") {
+      console.error(result.reason);
+    }
+  }
+
+  Deno.exit(1);
 } else if (code !== 0) {
-  if (stdout.length > 0) {
-    Deno.stdout.writeSync(stdout);
-  }
+  writeOutputWithTrailingNewline(stdout);
   Deno.exit(code);
 } else {
-  if (stdout.length > 0) {
-    Deno.stdout.writeSync(stdout);
-  }
+  writeOutputWithTrailingNewline(stdout);
   Deno.exit();
 }

--- a/sendApprise.ts
+++ b/sendApprise.ts
@@ -1,0 +1,29 @@
+import { getEnv } from "./config.ts";
+
+const appriseUrl = getEnv("APPRISE_URL");
+const appriseTitle =
+  getEnv("APPRISE_TITLE") ?? getEnv("MAIL_SUBJECT") ?? "Bahnhof Price Change";
+
+export async function sendApprise(text: string) {
+  if (!appriseUrl) {
+    return;
+  }
+
+  console.log("🔔 Sending Apprise notification...");
+
+  const command = new Deno.Command("apprise", {
+    args: ["-t", appriseTitle, "-b", text, appriseUrl],
+  });
+
+  const { code, stderr } = await command.output();
+
+  if (stderr.length > 0) {
+    Deno.stderr.writeSync(stderr);
+  }
+
+  if (code !== 0) {
+    throw new Error("❌ Apprise notification failed with exit code " + code + ".");
+  }
+
+  console.log("✅ Apprise notification sent");
+}

--- a/sendMail.ts
+++ b/sendMail.ts
@@ -1,41 +1,47 @@
-import { load, nodemailer } from "./deps.ts";
+import { getEnv } from "./config.ts";
+import { nodemailer } from "./deps.ts";
 
-const env = await load();
+const mailSubject = getEnv("MAIL_SUBJECT");
+const mailFrom = getEnv("MAIL_FROM");
+const mailTo = getEnv("MAIL_TO");
+const mailHost = getEnv("MAIL_HOST");
+const mailPort = getEnv("MAIL_PORT");
+const mailUsername = getEnv("MAIL_USERNAME");
+const mailPassword = getEnv("MAIL_PASSWORD");
 
-const mailSubject = env["MAIL_SUBJECT"] ?? Deno.env.get("MAIL_SUBJECT");
-const mailFrom = env["MAIL_FROM"] ?? Deno.env.get("MAIL_FROM");
-const mailTo = env["MAIL_TO"] ?? Deno.env.get("MAIL_TO");
-const mailHost = env["MAIL_HOST"] ?? Deno.env.get("MAIL_HOST");
-const mailPort = env["MAIL_PORT"] ?? Deno.env.get("MAIL_PORT");
-const mailUsername = env["MAIL_USERNAME"] ?? Deno.env.get("MAIL_USERNAME");
-const mailPassword = env["MAIL_PASSWORD"] ?? Deno.env.get("MAIL_PASSWORD");
-
-export function sendMail(text: string, callback: () => void) {
+export function sendMail(text: string) {
   console.log("💌 Sending mail...");
 
   const transporter = nodemailer.createTransport({
-    host: mailHost,
-    port: Number(mailPort),
+    host: mailHost!,
+    port: Number(mailPort!),
     auth: {
-      user: mailUsername,
-      pass: mailPassword,
+      user: mailUsername!,
+      pass: mailPassword!,
     },
   });
 
-  transporter.sendMail(
-    {
-      from: mailFrom,
-      to: mailTo,
-      subject: mailSubject,
-      text,
-    },
-    (error) => {
-      if (error) {
-        console.error(error);
-      } else {
+  return new Promise<void>((resolve, reject) => {
+    transporter.sendMail(
+      {
+        from: mailFrom!,
+        to: mailTo!,
+        subject: mailSubject!,
+        text,
+      },
+      (error) => {
+        if (error) {
+          const message = error instanceof Error
+            ? error.message
+            : String(error);
+
+          reject(new Error("❌ Mail notification failed: " + message));
+          return;
+        }
+
         console.log("✅ Mail sent");
-      }
-      callback && callback();
-    }
-  );
+        resolve();
+      },
+    );
+  });
 }

--- a/validateEnv.ts
+++ b/validateEnv.ts
@@ -1,0 +1,4 @@
+import { validateEnvironment } from "./config.ts";
+
+validateEnvironment({ includeCron: true });
+console.log("⚙️ Environment configuration looks good.");


### PR DESCRIPTION
With this PR, the checker can now notify through any [Apprise-supported URL](https://appriseit.com/services/), such as Discord, [ntfy.sh](https://ntfy.sh/), Slack, Telegram, Matrix, or many other services, by setting `APPRISE_URL`. Existing email notifications remain supported through the `MAIL_*` variables, and both channels can be enabled at the same time.

This PR also improves configuration validation by moving required environment checks to container startup. Invalid configurations now fail immediately when the container starts, before cron is installed, instead of failing later when the scheduled job runs.

# Changes

## Notification Improvements

* Add `sendApprise.ts` to send notifications through the `apprise` CLI.
* Add `APPRISE_URL` as the main Apprise target configuration.
* Add optional `APPRISE_TITLE`.

  * Falls back to `MAIL_SUBJECT`
  * Falls back again to `"Bahnhof Price Change"`
* Make email notification settings optional instead of always required.
* Require at least one configured notification channel:

  * `APPRISE_URL`
  * or a complete `MAIL_*` configuration
* Allow Apprise and email to be enabled simultaneously.
* Send notifications through all configured channels for the same price change event.
* Convert `sendMail` to return a `Promise` so notification backends can be handled consistently.
* Use `Promise.allSettled()` so a failure in one notification channel does not stop other channels from being attempted.
* Strip ANSI escape sequences from notification text before sending so Discord, ntfy, and other Apprise targets do not display terminal formatting artifacts.

## Configuration Validation

* Add `config.ts` to centralize:

  * Environment variable lookup
  * Required variable checks
  * Notification channel validation
* Add `validateEnv.ts` for dedicated startup validation.
* Keep runtime validation in `main.ts` as a safety net for direct script execution outside the container.
* Update `entrypoint.sh` to run validation before cron is installed.
* Add `set -e` to `entrypoint.sh` so invalid configuration causes the container to exit immediately.

## Docker and Development Improvements

* Install Apprise in the Docker image.
* Cache `validateEnv.ts` and `main.ts` during Docker build.
* Update README documentation for:

  * Apprise usage
  * Optional email configuration
  * Combined notification behavior

# Example Configuration

```env
APPRISE_URL=discord://webhook_id/webhook_token
APPRISE_TITLE=Bahnhof Price Alert
```

Or with both Apprise and email enabled:

```env
APPRISE_URL=ntfy://my-topic
MAIL_HOST=smtp.example.com
MAIL_PORT=587
MAIL_USER=user@example.com
MAIL_PASSWORD=secret
MAIL_FROM=user@example.com
MAIL_TO=alerts@example.com
```

# Validation

The following scenarios were tested:

* Built the Docker image successfully with Docker Compose
* Started the container successfully through Docker Compose
* Confirmed startup validation runs before cron setup
* Confirmed invalid configuration stops the container immediately
* Confirmed the container stays running after successful validation
* Confirmed the checker runs both from cron and during container startup
* Verified environment validation using an Apprise target
* Verified full `MAIL_*` configuration using [Mailpit](https://github.com/axllent/mailpit)
* Verified both Apprise and email notifications can be sent together
* Verified one failing notification backend does not prevent the other from sending