### PR TITLE
Add Apprise notification support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM denoland/deno:alpine
 
-RUN apk add --no-cache jq curl
+RUN apk add --no-cache jq curl apprise
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,33 @@
 # Bahnhof Price Check
 
-Check the current price of Bahnhof's internet service and send an email if the price has changed.
+Check the current price of Bahnhof's internet service and send a notification if the price has changed.
 
 ## Usage
 
 ### Docker compose
 
+Use Apprise by setting `APPRISE_URL` to
+[any URL supported by Apprise](https://appriseit.com/services/), such as
+`discord://...` or `ntfy://...`.
+
+```yaml
+services:
+  bahnhof-price-checker:
+    image: ghcr.io/patrikelfstrom/bahnhof-price-checker:latest
+    container_name: bahnhof-price-checker
+    environment:
+      - ADDRESS=Rådhusgatan 5, 590 37 Kisa, Sweden
+      - CURRENT_SPEED=500/100
+      - CURRENT_PRICE=459
+      - APPRISE_URL=discord://{webhook_id}/{webhook_token}
+      - APPRISE_TITLE=Bahnhof Price Change
+      - CRON_SCHEDULE=0 0 * * *
+    restart: always
 ```
-version: '3'
+
+You can also use email notifications by setting all `MAIL_*` variables:
+
+```yaml
 services:
   bahnhof-price-checker:
     image: ghcr.io/patrikelfstrom/bahnhof-price-checker:latest
@@ -27,10 +47,17 @@ services:
     restart: always
 ```
 
+At least one notification channel is required: set `APPRISE_URL` or all `MAIL_*`
+variables. If both Apprise and email are configured, both notifications will be
+sent.
+
+`APPRISE_TITLE` is optional and defaults to `MAIL_SUBJECT` or
+`Bahnhof Price Change`.
+
 ### Call shell scripts directly
 
 Clone the repo and just call comparePrice.sh with your current speed, price and address.
-No mail will be sent using this method.
+No notification will be sent using this method.
 
 Requires jq, cURL and Sed.
 

--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,5 @@
 import { dirname, fromFileUrl, join, load } from "./deps.ts";
+import { sendApprise } from "./sendApprise.ts";
 import { sendMail } from "./sendMail.ts";
 
 console.log("💸 Running Bahnhof Price Checker...");
@@ -9,6 +10,16 @@ const environmentVariables = [
   "ADDRESS",
   "CURRENT_SPEED",
   "CURRENT_PRICE",
+];
+
+for (const variable of environmentVariables) {
+  if (Deno.env.has(variable) === false && env[variable] === undefined) {
+    console.error(`❌ Required environment variable '${variable}' is not set.`);
+    Deno.exit(1);
+  }
+}
+
+const mailEnvironmentVariables = [
   "MAIL_SUBJECT",
   "MAIL_FROM",
   "MAIL_TO",
@@ -18,11 +29,28 @@ const environmentVariables = [
   "MAIL_PASSWORD",
 ];
 
-for (const variable of environmentVariables) {
-  if (Deno.env.has(variable) === false && env[variable] === undefined) {
+const getEnv = (variable: string) => env[variable] ?? Deno.env.get(variable);
+const missingMailVariables = mailEnvironmentVariables.filter((variable) =>
+  getEnv(variable) === undefined
+);
+const isMailConfigured = missingMailVariables.length === 0;
+const isMailPartiallyConfigured =
+  missingMailVariables.length < mailEnvironmentVariables.length;
+const isAppriseConfigured = Boolean(getEnv("APPRISE_URL"));
+
+if (isMailPartiallyConfigured && !isMailConfigured) {
+  for (const variable of missingMailVariables) {
     console.error(`❌ Required environment variable '${variable}' is not set.`);
-    Deno.exit(1);
   }
+
+  Deno.exit(1);
+}
+
+if (!isMailConfigured && !isAppriseConfigured) {
+  console.error(
+    "❌ At least one notification channel must be configured. Set APPRISE_URL or all MAIL_* variables.",
+  );
+  Deno.exit(1);
 }
 
 const address = env["ADDRESS"] ?? Deno.env.get("ADDRESS");
@@ -37,28 +65,53 @@ const command = new Deno.Command(join(currentDirectory, "./comparePrices.sh"), {
 const { code, stdout, stderr } = command.outputSync();
 const response = new TextDecoder().decode(stdout);
 
+function writeOutputWithTrailingNewline(output: Uint8Array) {
+  if (output.length === 0) {
+    return;
+  }
+
+  Deno.stdout.writeSync(output);
+
+  if (output[output.length - 1] !== 10) {
+    Deno.stdout.writeSync(new TextEncoder().encode("\n"));
+  }
+}
+
+function stripAnsiEscapeCodes(text: string) {
+  return text.replace(/\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g, "").trim();
+}
+
 if (stderr.length > 0) {
   Deno.stderr.writeSync(stderr);
 }
 
 if (code === 3) {
-  if (stdout.length > 0) {
-    Deno.stdout.writeSync(stdout);
+  writeOutputWithTrailingNewline(stdout);
+
+  const cleanResponse = stripAnsiEscapeCodes(response);
+  const notifications: Promise<void>[] = [];
+
+  if (isMailConfigured) {
+    notifications.push(sendMail(cleanResponse));
   }
 
-  const cleanResponse = response.replace(/(\[0;31m|\[0;32m|\[0m)/g, "");
+  if (isAppriseConfigured) {
+    notifications.push(sendApprise(cleanResponse));
+  }
 
-  sendMail(cleanResponse, () => {
-    Deno.exit(1);
-  });
+  const notificationResults = await Promise.allSettled(notifications);
+
+  for (const result of notificationResults) {
+    if (result.status === "rejected") {
+      console.error(result.reason);
+    }
+  }
+
+  Deno.exit(1);
 } else if (code !== 0) {
-  if (stdout.length > 0) {
-    Deno.stdout.writeSync(stdout);
-  }
+  writeOutputWithTrailingNewline(stdout);
   Deno.exit(code);
 } else {
-  if (stdout.length > 0) {
-    Deno.stdout.writeSync(stdout);
-  }
+  writeOutputWithTrailingNewline(stdout);
   Deno.exit();
 }

--- a/sendApprise.ts
+++ b/sendApprise.ts
@@ -1,0 +1,34 @@
+import { load } from "./deps.ts";
+
+const env = await load();
+
+const appriseUrl = env["APPRISE_URL"] ?? Deno.env.get("APPRISE_URL");
+const appriseTitle = env["APPRISE_TITLE"] ?? Deno.env.get("APPRISE_TITLE") ??
+  env["MAIL_SUBJECT"] ?? Deno.env.get("MAIL_SUBJECT") ??
+  "Bahnhof Price Change";
+
+export async function sendApprise(text: string) {
+  if (!appriseUrl) {
+    return;
+  }
+
+  console.log("🔔 Sending Apprise notification...");
+
+  const command = new Deno.Command("apprise", {
+    args: ["-t", appriseTitle, "-b", text, appriseUrl],
+  });
+
+  const { code, stderr } = await command.output();
+
+  if (stderr.length > 0) {
+    Deno.stderr.writeSync(stderr);
+  }
+
+  if (code !== 0) {
+    throw new Error(
+      "❌ Apprise notification failed with exit code " + code + ".",
+    );
+  }
+
+  console.log("✅ Apprise notification sent");
+}

--- a/sendMail.ts
+++ b/sendMail.ts
@@ -10,7 +10,7 @@ const mailPort = env["MAIL_PORT"] ?? Deno.env.get("MAIL_PORT");
 const mailUsername = env["MAIL_USERNAME"] ?? Deno.env.get("MAIL_USERNAME");
 const mailPassword = env["MAIL_PASSWORD"] ?? Deno.env.get("MAIL_PASSWORD");
 
-export function sendMail(text: string, callback: () => void) {
+export function sendMail(text: string) {
   console.log("💌 Sending mail...");
 
   const transporter = nodemailer.createTransport({
@@ -22,20 +22,26 @@ export function sendMail(text: string, callback: () => void) {
     },
   });
 
-  transporter.sendMail(
-    {
-      from: mailFrom,
-      to: mailTo,
-      subject: mailSubject,
-      text,
-    },
-    (error) => {
-      if (error) {
-        console.error(error);
-      } else {
+  return new Promise<void>((resolve, reject) => {
+    transporter.sendMail(
+      {
+        from: mailFrom,
+        to: mailTo,
+        subject: mailSubject,
+        text,
+      },
+      (error) => {
+        if (error) {
+          const message = error instanceof Error
+            ? error.message
+            : String(error);
+          reject(new Error("❌ Mail notification failed: " + message));
+          return;
+        }
+
         console.log("✅ Mail sent");
-      }
-      callback && callback();
-    }
-  );
+        resolve();
+      },
+    );
+  });
 }


### PR DESCRIPTION
This PR supersedes [#3](https://github.com/patrikelfstrom/bahnhof-price-checker/pull/3) with a smaller, focused PR for Apprise support.

It adds Apprise as an optional notification backend for price change alerts while keeping existing email notifications working.

## Changes
- add `sendApprise.ts` for Apprise notifications
- install `apprise` in the Docker image
- make email configuration optional when `APPRISE_URL` is used
- update mail sending flow to support multiple notification backends
- keep only the minimal startup validation needed to support optional mail vs Apprise
- update the README with Apprise usage and configuration details